### PR TITLE
TreeCapitator IMC support

### DIFF
--- a/common/rebelkeithy/mods/metallurgy/integration/TreeCapitatorIntegration.java
+++ b/common/rebelkeithy/mods/metallurgy/integration/TreeCapitatorIntegration.java
@@ -1,0 +1,31 @@
+package rebelkeithy.mods.metallurgy.integration;
+
+import net.minecraft.nbt.NBTTagCompound;
+import rebelkeithy.mods.metallurgy.api.IOreInfo;
+import rebelkeithy.mods.metallurgy.core.MetallurgyCore;
+import rebelkeithy.mods.metallurgy.core.metalsets.MetalSet;
+import rebelkeithy.mods.metallurgy.core.metalsets.OreInfo;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.event.FMLInterModComms;
+
+public class TreeCapitatorIntegration
+{
+    public static void init()
+    {
+        if (Loader.isModLoaded("TreeCapitator"))
+        {
+            String axeList = "";
+            
+            for (MetalSet ms : MetallurgyCore.getMetalSetList())
+                for (IOreInfo oi : ms.getOreList().values())
+                    if (oi.isEnabled() && ((OreInfo) oi).axe != null)
+                        axeList += "; " + ((OreInfo) oi).axe.itemID;
+            
+            NBTTagCompound tpModCfg = new NBTTagCompound();
+            tpModCfg.setString("modID", "Metallurgy3Base");
+            tpModCfg.setString("axeIDList", axeList);
+            
+            FMLInterModComms.sendMessage("TreeCapitator", "ThirdPartyModConfig", tpModCfg);
+        }
+    }
+}

--- a/common/rebelkeithy/mods/metallurgy/metals/MetallurgyMetals.java
+++ b/common/rebelkeithy/mods/metallurgy/metals/MetallurgyMetals.java
@@ -23,6 +23,7 @@ import rebelkeithy.mods.metallurgy.core.metalsets.ISwordHitListener;
 import rebelkeithy.mods.metallurgy.core.metalsets.MetalSet;
 import rebelkeithy.mods.metallurgy.core.metalsets.OreInfo;
 import rebelkeithy.mods.metallurgy.integration.ThaumcraftIntegration;
+import rebelkeithy.mods.metallurgy.integration.TreeCapitatorIntegration;
 import rebelkeithy.mods.metallurgy.metals.utilityItems.ItemFertilizer;
 import rebelkeithy.mods.metallurgy.metals.utilityItems.ItemIgniter;
 import rebelkeithy.mods.metallurgy.metals.utilityItems.tnt.EntityLargeTNTPrimed;
@@ -232,6 +233,8 @@ public class MetallurgyMetals {
 		addSwordEffects();
 		
 		proxy.registerParticles();
+		
+		TreeCapitatorIntegration.init();
 	}
 	
 	@PostInit


### PR DESCRIPTION
Adds code to send an IMC message to TreeCapitator to register Metallurgy axes as able to chop down trees.
